### PR TITLE
Add httpchk logic for customising HTTP checks

### DIFF
--- a/README
+++ b/README
@@ -31,3 +31,4 @@ Proxy Configuration Keys:
  - ssl: (Optional) Connect to the backend via ssl regardless of the port
  - ssl-verify: (Optional) Boolean, set to True to check SSL certs. False will not check
  - check: (Optional) perform port availability check, defaults to True set False to not check
+ - httpchk: (Optional) if the mode is HTTP, and checks are enabled, this will be appended to the httpchk option for the backend

--- a/requires.py
+++ b/requires.py
@@ -67,6 +67,9 @@ class ReverseProxyRequires(RelationBase):
             # Set default value for 'check' if not set
             if entry['check'] is None:
                 entry['check'] = True
+            # Set http check params if appropriate
+            if (entry['mode'] != 'http' or entry['check'] is False) and entry['httpchk']:
+                entry['httpchk'] = None
             # Check for http required options
             if entry['urlbase'] == entry['subdomain'] is None and entry['mode'] == 'http':
                 raise ProxyConfigError('"urlbase" or "subdomain" must be set in http mode')


### PR DESCRIPTION
Simple logic for allowing the options after `option httpchk` to be customised by a relation. This will also require changes to layer-haproxy to use this new setting and add the httpchk option to backends if it's set on the relation.