### PR TITLE
Added tcp+tls frontend mode for TLS-wrapped TCP connections

### DIFF
--- a/README
+++ b/README
@@ -18,7 +18,10 @@ Departed:
   - when 'departed' remove self.config from the configuration
 
 Proxy Configuration Keys:
- - mode: (Optional) set 'tcp' or 'http' routing, defaults to 'http'
+ - mode: (Optional) set 'tcp', 'tcp+tls' or 'http' routing, defaults to 'http'
+         NOTE: tcp+tls is the same as tcp, however load balancers should ensure that if TLS is enabled,
+	       tcp+tls frontends will treat the frontend TCP connection as being TLS-encrypted from the client
+	       this is to allow things like TLS offload and inspection on TCP sockets
  - urlbase: (Optional if subdomain is provided) the base url to redirect to his charm, including leading /
  - acl-local: (Optional) restrict access to local ip address ranges for this backend
  - rewrite-path: (Optional) remove the urlbase from the path 

--- a/operator_requires.py
+++ b/operator_requires.py
@@ -53,11 +53,11 @@ class ProxyConfig:
 
         # Validate mode setting
 
-        if self._config["mode"] not in ("http", "tcp"):
+        if self._config["mode"] not in ("http", "tcp", "tcp+tls"):
             if not self._config["mode"]:
                 self._config["mode"] = "http"
             else:
-                raise ProxyConfigError('"mode" setting must be http or tcp if provided')
+                raise ProxyConfigError('"mode" setting must be http, tcp or tcp+tls if provided')
         # Set default value for 'check' if not set
 
         if self._config["check"] is None:

--- a/requires.py
+++ b/requires.py
@@ -59,11 +59,11 @@ class ReverseProxyRequires(RelationBase):
                 if not entry[rconfig]:
                     raise ProxyConfigError('"{}" is required'.format(rconfig))
             # Check that mode is valid, set default if not provided
-            if entry['mode'] not in ('http', 'tcp'):
+            if entry['mode'] not in ('http', 'tcp', 'tcp+tls'):
                 if not entry['mode']:
                     entry['mode'] = 'http'
                 else:
-                    raise ProxyConfigError('"mode" setting must be http or tcp if provided')
+                    raise ProxyConfigError('"mode" setting must be http, tcp or tcp+tls if provided')
             # Set default value for 'check' if not set
             if entry['check'] is None:
                 entry['check'] = True


### PR DESCRIPTION
This introduces a third frontend type - tcp+tls. It's basically a way to indicate that you would like the TCP frontend to terminate TLS at the load balancer, for services which do not provide TLS support themselves, or services which do not support one or more encryption methods which would be supported if the load balancer was able to handle encryption - for example, haproxy and letsencrypt.

The primary charm example would be to support haproxy's TLS offloading TCP connections, which is a valid configuration for haproxy. Rather that adding yet another option to the TCP frontend type in the relation, I chose to go with tcp+tls to make it more explicit, and given there is already an 'ssl' option on the relation that indicates whether or not the backend should use TLS - the tcp+tls frontend type avoids ambiguity.